### PR TITLE
Add toggleable '-ai' exclusion extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# no-ai-search
+# No AI Search
+
+This Chrome extension automatically appends `-ai` to search queries when enabled.
+Use the popup to toggle the feature on or off. The setting is stored in `chrome.storage.local` and read by `content.js` on each page.
+
+## Load the extension
+1. Open Chrome and navigate to `chrome://extensions/`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this repository directory.
+4. Use the extension icon to toggle the "-ai" exclusion.

--- a/content.js
+++ b/content.js
@@ -1,0 +1,17 @@
+chrome.storage.local.get({enabled: true}, ({enabled}) => {
+  if (!enabled) return;
+
+  function appendExcludeAI(input) {
+    if (input && input.value && !input.value.includes('-ai')) {
+      input.value = input.value + ' -ai';
+    }
+  }
+
+  const searchInputs = document.querySelectorAll('input[name="q"]');
+  searchInputs.forEach(appendExcludeAI);
+
+  document.addEventListener('submit', (e) => {
+    const input = e.target.querySelector('input[name="q"]');
+    appendExcludeAI(input);
+  }, true);
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,18 @@
+{
+  "manifest_version": 3,
+  "name": "No AI Search",
+  "version": "1.0",
+  "description": "Automatically exclude AI results by appending '-ai' to search queries.",
+  "permissions": ["storage"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "No AI Search"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ]
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>No AI Search</title>
+  <style>
+    body { font-family: sans-serif; margin: 10px; }
+    label { display: flex; align-items: center; gap: 8px; }
+  </style>
+</head>
+<body>
+  <label>
+    <input type="checkbox" id="toggle" />
+    -ai を検索から除外
+  </label>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('toggle');
+  chrome.storage.local.get({enabled: true}, (data) => {
+    toggle.checked = data.enabled;
+  });
+  toggle.addEventListener('change', () => {
+    chrome.storage.local.set({enabled: toggle.checked});
+  });
+});


### PR DESCRIPTION
## Summary
- create a manifest for a small Chrome extension
- add popup with simple enable/disable checkbox
- store the state in `chrome.storage.local` via popup.js
- read the value in content.js to append `-ai` when enabled
- update README with load instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687270adb4d883279c3b5f8b0d11ac84